### PR TITLE
测试通过

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+yarn.lock

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,9 @@ describe('this', function () {
       say: function () {
         setTimeout(() => {
           // this 是什么？想想为什么？
-          this.should.equal(null)
+          // 由于是在obj对象上调用的函数，调用位置会使用obj上下文来引用function
+          // 而箭头函数会绑定当前函数的上下文
+          this.should.equal(obj)
           done()
         }, 0)
       }
@@ -15,7 +17,9 @@ describe('this', function () {
   it('global', function () {
     function test() {
       // this 是什么？想想为什么？
-      this.should.equal(null)
+      // 此时使用的时默认绑定在非严格模式下为全局对象
+      // node中的全局对象为global
+      this.should.equal(global)
     }
     test()
   })
@@ -26,7 +30,10 @@ describe('this', function () {
         say: function () {
           function _say() {
             // this 是什么？想想为什么？
-            this.should.equal(null)
+            // say引用的是立即执行函数的返回值
+            // 在执行函数时 obj对象还没有被赋值 所以obj为undefined
+            // bind undefined 时在非严格模式下为全局对象
+            this.should.equal(global)
           }
           return _say.bind(obj)
         }()
@@ -39,7 +46,8 @@ describe('this', function () {
       obj.say = function () {
         function _say() {
           // this 是什么？想想为什么？
-          this.should.equal(null)
+          // 立即执行函数执行时obj已经定义 正常将obj对象作为_say的上下文
+          this.should.equal(obj)
         }
         return _say.bind(obj)
       }()


### PR DESCRIPTION
1. 由于是在obj对象上调用的函数，调用位置会使用obj上下文来引用function，而箭头函数会绑定当前函数的上下文，因此this为obj。
2. 此时使用的是默认绑定在非严格模式下为全局对象，而node中的全局对象为global，因此this为global。
3. say引用的是立即执行函数的返回值，在执行函数时obj对象还没有被赋值，所以obj为undefined，而bind undefined 时在非严格模式下为全局对象，因此this为global。
4. 立即执行函数执行时obj已经定义 正常将obj对象作为_say的上下文，因此this为obj。
